### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,6 +9,9 @@ on:
   pull_request:
     branches: [master]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/casmith/sync-todoist-to-habitica/security/code-scanning/2](https://github.com/casmith/sync-todoist-to-habitica/security/code-scanning/2)

In general, fix this by defining an explicit `permissions:` block either at the top (workflow level, applying to all jobs) or individually per job, granting only the minimal scopes required (typically `contents: read` for a basic build/test workflow). For this particular workflow, the jobs interact with external services (Docker Hub, Codecov) via secrets and do not need to modify GitHub resources, so read-only contents access is sufficient.

The best minimal-change fix is to add a workflow-level `permissions:` block just after the `on:` section and before `jobs:`. This will apply to both `build` and `cleanup_pr_tag` jobs without altering their existing functionality. Set `contents: read`, which matches the recommended minimal default for most read-only CI workflows. No additional imports, methods, or other code changes are required; it’s just a YAML configuration addition in `.github/workflows/build.yml` between the `on:` block and the `jobs:` block.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
