### PR TITLE
Potential fix for code scanning alert no. 3: Clear-text logging of sensitive information

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,7 +22,10 @@ if (fs.existsSync(configFile)) {
   const habiticaApiKey = process.env.HABITICA_API_KEY;
   const todoistApiToken = process.env.TODOIST_API_TOKEN;
 
-  console.log(habiticaApiKey, habiticaApiUser, todoistApiToken);
+  logger.info(
+    "Read configuration values from environment variables " +
+      "(HABITICA_API_USER, HABITICA_API_KEY, TODOIST_API_TOKEN)",
+  );
   if (!!habiticaApiUser && !!habiticaApiKey && !!todoistApiToken) {
     logger.info("Applying configuration from environment variables");
     config = {


### PR DESCRIPTION
Potential fix for [https://github.com/casmith/sync-todoist-to-habitica/security/code-scanning/3](https://github.com/casmith/sync-todoist-to-habitica/security/code-scanning/3)

In general, the fix is to avoid logging sensitive values (API keys, tokens, secrets) in clear text. Instead, only log non-sensitive context (e.g., “configuration loaded from env”), or, if necessary, log redacted versions (e.g., last 4 characters) so that debugging is still possible without exposing the full secret.

For this specific code, the problem is on line 25:

```js
25:   console.log(habiticaApiKey, habiticaApiUser, todoistApiToken);
```

We should remove the direct logging of these environment-derived secrets. To keep useful diagnostics without changing functionality, we can instead log via the existing `logger` that configuration is being read from environment variables, optionally indicating which variables are set without exposing their values. For example, we can report booleans for whether each variable is present, or log only a masked version of the user ID if that is not considered secret.

Since we must not assume anything about `logger`’s implementation, the safest minimal change is:

- Replace line 25 with a high-level info message that does not contain any of the secret values, e.g.:
  - `logger.info("Loaded configuration from environment variables (HABITICA_API_USER, HABITICA_API_KEY, TODOIST_API_TOKEN)");`

This requires no new imports and does not alter subsequent logic: `habiticaApiUser`, `habiticaApiKey`, and `todoistApiToken` are still read and used to build `config`, but they are no longer printed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
