### PR TITLE
Implement frequency parsing for remaining recurring task patterns

### DIFF
--- a/test/todoist.spec.js
+++ b/test/todoist.spec.js
@@ -136,11 +136,56 @@ describe("todoist", function () {
       });
     });
 
-    it('is given "every monday, friday"');
-    it('is given "every 3 days"');
-    it('is given "every 3rd friday"');
-    it('is given "every 27th"');
-    it('is given "every jan 27th"');
+    it('is given "every monday, friday"', function () {
+      expect(
+        this.todoist.calculateFrequency("every monday, friday"),
+      ).to.deep.equal({
+        frequency: "weekly",
+        repeat: {
+          su: false,
+          m: true,
+          t: false,
+          w: false,
+          th: false,
+          f: true,
+          s: false,
+        },
+      });
+    });
+    it('is given "every 3 days"', function () {
+      expect(this.todoist.calculateFrequency("every 3 days")).to.deep.equal({
+        frequency: "daily",
+        everyX: 3,
+      });
+    });
+    it('is given "every 3rd friday"', function () {
+      expect(this.todoist.calculateFrequency("every 3rd friday")).to.deep.equal(
+        {
+          frequency: "weekly",
+          everyX: 3,
+          repeat: {
+            su: false,
+            m: false,
+            t: false,
+            w: false,
+            th: false,
+            f: true,
+            s: false,
+          },
+        },
+      );
+    });
+    it('is given "every 27th"', function () {
+      expect(this.todoist.calculateFrequency("every 27th")).to.deep.equal({
+        frequency: "monthly",
+        daysOfMonth: [27],
+      });
+    });
+    it('is given "every jan 27th"', function () {
+      expect(this.todoist.calculateFrequency("every jan 27th")).to.deep.equal({
+        frequency: "yearly",
+      });
+    });
     it('is given "every other monday"', function () {
       expect(
         this.todoist.calculateFrequency("every other monday"),

--- a/todoist.js
+++ b/todoist.js
@@ -134,6 +134,53 @@ module.exports = class Todoist {
       };
     }
 
+    // "every monday, friday" - multiple days of the week
+    const multiDayMatch = dateExpr.match(/^every\s+(.+,\s*.+)$/i);
+    if (multiDayMatch) {
+      const days = multiDayMatch[1].split(/\s*,\s*/);
+      const repeat = this.getRepeat();
+      days.forEach((d) => {
+        const day = this.getDay(d.trim());
+        if (day) repeat[day] = true;
+      });
+      return { frequency: "weekly", repeat };
+    }
+
+    // "every 3rd friday" - every Nth weekday
+    const nthDayMatch = dateExpr.match(
+      /^every\s+(\d+)(?:st|nd|rd|th)\s+(monday|tuesday|wednesday|thursday|friday|saturday|sunday|mon|tue|tues|wed|thurs|thu|fri|sat|sun)\s*$/i,
+    );
+    if (nthDayMatch) {
+      return {
+        frequency: "weekly",
+        everyX: parseInt(nthDayMatch[1]),
+        repeat: this.getRepeat(this.getDay(nthDayMatch[2])),
+      };
+    }
+
+    // "every 3 days" - every N days
+    const everyNDaysMatch = dateExpr.match(/^every\s+(\d+)\s+days?$/i);
+    if (everyNDaysMatch) {
+      return { frequency: "daily", everyX: parseInt(everyNDaysMatch[1]) };
+    }
+
+    // "every jan 27th" - specific month and day, yearly
+    const monthDayMatch = dateExpr.match(
+      /^every\s+(jan|feb|mar|apr|may|jun|jul|aug|sep|oct|nov|dec)\w*\s+(\d+)(?:st|nd|rd|th)?$/i,
+    );
+    if (monthDayMatch) {
+      return { frequency: "yearly" };
+    }
+
+    // "every 27th" - specific day of month
+    const dayOfMonthMatch = dateExpr.match(/^every\s+(\d+)(?:st|nd|rd|th)$/i);
+    if (dayOfMonthMatch) {
+      return {
+        frequency: "monthly",
+        daysOfMonth: [parseInt(dayOfMonthMatch[1])],
+      };
+    }
+
     if (dateExpr === "every month" || dateExpr === "monthly") {
       return {
         frequency: "monthly",
@@ -187,7 +234,7 @@ module.exports = class Todoist {
       f: false,
       s: false,
     };
-    repeat[day] = true;
+    if (day) repeat[day] = true;
     return repeat;
   }
 };


### PR DESCRIPTION
## Summary
- Implement `calculateFrequency` for 5 previously unsupported Todoist recurring patterns: multi-day (`every monday, friday`), every-N-days (`every 3 days`), Nth weekday (`every 3rd friday`), day-of-month (`every 27th`), and month+day (`every jan 27th`)
- Unskip and implement all 5 pending test cases

Closes #121

## Test plan
- [x] All 43 tests pass (previously 38 passing, 5 pending)
- [ ] Verify recurring task syncing with real Todoist tasks using the new patterns