### PR TITLE
Replace lodash with native JavaScript equivalents

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,6 @@
       "dependencies": {
         "axios": "^1.14.0",
         "jsonfile": "^6.2.0",
-        "lodash": "^4.17.23",
         "moment": "^2.30.1",
         "uuid": "^13.0.0",
         "winston": "^3.19.0"
@@ -58,6 +57,7 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -685,6 +685,7 @@
       "resolved": "https://registry.npmjs.org/axios/-/axios-1.14.0.tgz",
       "integrity": "sha512-3Y8yrqLSwjuzpXuZ0oIYZ/XGgLwUIBU3uLvbcpb0pidD9ctpShJd43KSlEEkVQg6DS0G9NKyzOvBfUtDKEyHvQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "follow-redirects": "^1.15.11",
         "form-data": "^4.0.5",
@@ -774,6 +775,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -2187,12 +2189,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/lodash": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
-      "license": "MIT"
     },
     "node_modules/lodash.flattendeep": {
       "version": "4.4.0",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
   "dependencies": {
     "axios": "^1.14.0",
     "jsonfile": "^6.2.0",
-    "lodash": "^4.17.23",
     "moment": "^2.30.1",
     "uuid": "^13.0.0",
     "winston": "^3.19.0"

--- a/sync.js
+++ b/sync.js
@@ -1,7 +1,6 @@
 "use strict";
 
-const _ = require("lodash"),
-  moment = require("moment"),
+const moment = require("moment"),
   jsonFile = require("jsonfile");
 
 module.exports = class Sync {
@@ -44,14 +43,10 @@ module.exports = class Sync {
       .then((tasks) => {
         this.logger.info("Loaded tasks");
         config.habiticaTasks = tasks;
-        config.aliases = _.reduce(
-          tasks,
-          (acc, task) => {
-            acc[task.alias] = task._id;
-            return acc;
-          },
-          {},
-        );
+        config.aliases = tasks.reduce((acc, task) => {
+          acc[task.alias] = task._id;
+          return acc;
+        }, {});
       })
       .then(() => {
         return this.habitica.listDailies().then((dailies) => {
@@ -132,7 +127,7 @@ module.exports = class Sync {
         .map((item) => {
           // if the recurring task's due date is in the future, this means it was probably completed
           // unless it was simply created with a future due date
-          const dueDate = _.get(item, "due.date");
+          const dueDate = item?.due?.date;
           if (dueDate && moment(dueDate).isAfter(moment())) {
             // try to find a matching "daily" in habitica and score it
             const task = config.habiticaDailies.find(
@@ -201,7 +196,7 @@ module.exports = class Sync {
         } else {
           await this.deleteTask(item);
         }
-      } else if (_.includes(aliases, item.id + "")) {
+      } else if (aliases.includes(item.id + "")) {
         await this.updateTask(item, config.aliases[item.id]);
       } else {
         if (!item.parent_id) {
@@ -278,12 +273,14 @@ module.exports = class Sync {
   }
 
   filterIgnoredProjects(config) {
-    const ignoreProjectIds = config.ignoreProjects.map((projectName) => {
-      return _.keyBy(config.projects, "name")[projectName].id;
-    });
+    const projectsByName = Object.fromEntries(
+      (config.projects || []).map((p) => [p.name, p]),
+    );
+    const ignoreProjectIds = config.ignoreProjects.map(
+      (projectName) => projectsByName[projectName].id,
+    );
     return function (item) {
-      const projectId = item.project_id;
-      return !_.includes(ignoreProjectIds, projectId);
+      return !ignoreProjectIds.includes(item.project_id);
     };
   }
 

--- a/test/sync.spec.js
+++ b/test/sync.spec.js
@@ -4,6 +4,7 @@ const expect = require("chai").expect;
 const LoggerStub = require("./loggerStub");
 const sinon = require("sinon");
 const { v4: uuidv4 } = require("uuid");
+const moment = require("moment");
 
 class FakeHabitica {
   constructor() {
@@ -226,6 +227,134 @@ describe("sync", function () {
     const newTasks = await this.habitica.listTasks();
     expect(newTasks.find((t) => t.text === "My renamed task")).to.exist;
   });
+  describe("filterIgnoredProjects", function () {
+    it("filters out items belonging to ignored projects", function () {
+      const config = {
+        projects: [
+          { name: "Work", id: 1 },
+          { name: "Personal", id: 2 },
+          { name: "Shopping", id: 3 },
+        ],
+        ignoreProjects: ["Personal"],
+      };
+      const filter = this.sync.filterIgnoredProjects(config);
+      expect(filter({ project_id: 1 })).to.be.true;
+      expect(filter({ project_id: 2 })).to.be.false;
+      expect(filter({ project_id: 3 })).to.be.true;
+    });
+
+    it("filters out multiple ignored projects", function () {
+      const config = {
+        projects: [
+          { name: "Work", id: 1 },
+          { name: "Personal", id: 2 },
+          { name: "Shopping", id: 3 },
+        ],
+        ignoreProjects: ["Personal", "Shopping"],
+      };
+      const filter = this.sync.filterIgnoredProjects(config);
+      expect(filter({ project_id: 1 })).to.be.true;
+      expect(filter({ project_id: 2 })).to.be.false;
+      expect(filter({ project_id: 3 })).to.be.false;
+    });
+
+    it("allows all items when no projects are ignored", function () {
+      const config = {
+        projects: [
+          { name: "Work", id: 1 },
+          { name: "Personal", id: 2 },
+        ],
+        ignoreProjects: [],
+      };
+      const filter = this.sync.filterIgnoredProjects(config);
+      expect(filter({ project_id: 1 })).to.be.true;
+      expect(filter({ project_id: 2 })).to.be.true;
+    });
+
+    it("handles missing projects array gracefully", function () {
+      const config = {
+        projects: undefined,
+        ignoreProjects: [],
+      };
+      const filter = this.sync.filterIgnoredProjects(config);
+      expect(filter({ project_id: 1 })).to.be.true;
+    });
+  });
+
+  describe("updateDailies", function () {
+    it("scores a recurring task with a future due date when a matching daily exists", async function () {
+      const futureDate = moment().add(1, "day").format("YYYY-MM-DD");
+      const items = [
+        {
+          id: uuidv4(),
+          checked: false,
+          content: "Todoist: Daily Goal",
+          due: { date: futureDate, is_recurring: true },
+          project_id: 1,
+        },
+      ];
+      const tasks = syncDataFor(6, 0, items);
+      sinon.stub(this.todoist, "sync").returns(Promise.resolve(tasks));
+      sinon.stub(this.todoist, "listTasks").returns(Promise.resolve(items));
+
+      await this.sync.sync({});
+
+      const dailies = await this.habitica.listDailies();
+      const daily = dailies.find((t) => t.text === "Todoist: Daily Goal");
+      expect(daily.checked).to.equal(true);
+    });
+
+    it("handles recurring tasks with no due object via optional chaining", async function () {
+      const items = [
+        {
+          id: uuidv4(),
+          checked: false,
+          content: "Recurring no due",
+          due: null,
+          project_id: 1,
+        },
+      ];
+      // Mark as recurring by giving it due.is_recurring - but due is null here,
+      // so we need to ensure isTaskRecurring matches. We'll set due after to test the path.
+      const tasks = syncDataFor(6, 0, items);
+      sinon.stub(this.todoist, "sync").returns(Promise.resolve(tasks));
+      sinon.stub(this.todoist, "listTasks").returns(Promise.resolve(items));
+
+      // This should not throw even though item.due is null
+      await this.sync.sync({});
+
+      // Task should still be created (it's not recurring without due, so it goes through updateTasks)
+      const habiticaTasks = await this.habitica.listTasks();
+      expect(habiticaTasks.length).to.be.greaterThan(0);
+    });
+  });
+
+  describe("aliases via reduce", function () {
+    it("builds aliases map from habitica tasks", async function () {
+      // Pre-populate habitica with a known task
+      this.habitica.tasks.push({
+        _id: "hab-123",
+        alias: "todo-456",
+        text: "Existing task",
+        checklist: [],
+      });
+
+      const items = [
+        { id: "todo-456", checked: false, content: "Existing task" },
+      ];
+      const tasks = syncDataFor(6, 0, items);
+      sinon.stub(this.todoist, "sync").returns(Promise.resolve(tasks));
+      sinon.stub(this.todoist, "listTasks").returns(Promise.resolve(items));
+
+      await this.sync.sync({});
+
+      // The task should have been updated (not created new) since alias matched
+      const habiticaTasks = await this.habitica.listTasks();
+      const matching = habiticaTasks.filter((t) => t.text === "Existing task");
+      expect(matching.length).to.be.greaterThan(0);
+    });
+  });
+
   // Pending tests:
 
   // scoring of checklist items

--- a/todoist.js
+++ b/todoist.js
@@ -1,6 +1,5 @@
 "use strict";
 
-const _ = require("lodash");
 const baseUrl = "https://api.todoist.com/api/v1";
 const axios = require("axios");
 
@@ -69,7 +68,7 @@ module.exports = class Todoist {
   }
 
   isTaskRecurring(task) {
-    return _.get(task, "due.is_recurring", false);
+    return task?.due?.is_recurring ?? false;
   }
 
   listProjects() {
@@ -199,7 +198,7 @@ module.exports = class Todoist {
   }
 
   getDay(dayExpr) {
-    switch (_.toLower(dayExpr)) {
+    switch (dayExpr.toLowerCase()) {
       case "monday":
       case "mon":
       case "m":


### PR DESCRIPTION
## Summary
- Replace all lodash calls (`_.reduce`, `_.get`, `_.keyBy`, `_.includes`, `_.toLower`) with native JS equivalents (`Array.reduce`, optional chaining, `Object.fromEntries`, `Array.includes`, `String.toLowerCase`)
- Remove `lodash` from dependencies

Closes #123

## Test plan
- [x] All 43 tests pass
- [ ] Verify sync behavior in production