### PR TITLE
fix: preserve original error context in habitica.js (#125)

### DIFF
--- a/habitica.js
+++ b/habitica.js
@@ -23,12 +23,13 @@ module.exports = class Habitica {
   }
 
   _requestError(err) {
-    const method = (err.config.method || "").toUpperCase();
-    const url = err.config.url || "unknown";
+    const config = err.config || {};
+    const method = (config.method || "").toUpperCase();
+    const url = config.url || "unknown";
     const status = err.response
       ? `${err.response.status} ${err.response.statusText}`
       : err.message;
-    return new Error(`${method} ${url} failed: ${status}`);
+    return new Error(`${method} ${url} failed: ${status}`, { cause: err });
   }
 
   _setupRetryInterceptor() {

--- a/test/habitica.spec.js
+++ b/test/habitica.spec.js
@@ -78,7 +78,25 @@ describe("habitica", function () {
     return this.habitica.scoreChecklistItem("123", "1");
   });
 
-  it("fails to score a checklist item", function () {});
+  it("fails to score a checklist item and preserves error cause", async function () {
+    const Habitica = require("../habitica");
+    const instance = axios.create();
+    const mock = new MockAdapter(instance);
+    const logger = {
+      info: sinon.stub(),
+      warn: sinon.stub(),
+      error: sinon.stub(),
+    };
+    const habitica = new Habitica(instance, logger);
+    mock.onPost("/tasks/123/checklist/1/score").reply(500);
+    try {
+      await habitica.scoreChecklistItem("123", "1");
+      expect.fail("should have thrown");
+    } catch (err) {
+      expect(err.message).to.include("failed");
+      expect(err).to.have.property("cause");
+    }
+  });
 
   describe("rate limit handling", function () {
     beforeEach(function () {
@@ -126,6 +144,7 @@ describe("habitica", function () {
       } catch (err) {
         expect(err.message).to.include("GET /tasks/123 failed");
         expect(err.message).to.include("500");
+        expect(err).to.have.property("cause");
       }
     });
   });


### PR DESCRIPTION
## Summary
- Add `{ cause: err }` to the `Error` thrown in `_requestError` so the original error is preserved
- Guard against missing `err.config` to prevent a secondary `TypeError`
- Add test coverage for `scoreChecklistItem` failure and `cause` propagation

Closes #125