### PR TITLE
feat: log and optionally score/delete orphaned habitica tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,21 @@ $ node index.js
 
 That's it! You can configure it to run on a schedule with something like crontab.
 
+## Orphaned task handling
+
+Habitica tasks created by this sync may become "orphaned" if their corresponding
+Todoist task disappears outside the sync window (for example, deleted directly
+in Todoist while the sync wasn't running, or after a sync token reset). On every
+run, any habitica task whose alias does not match a current Todoist task is
+logged as a warning so you can review it.
+
+To automatically act on orphans, set `habiticaOrphanAction` in `config.json` or
+the `HABITICA_ORPHAN_ACTION` environment variable to one of:
+
+- `log` (default) — only log the orphans
+- `score` — score them in Habitica (treats them as completed)
+- `delete` — delete them from Habitica
+
 ## License
 
 ```

--- a/index.js
+++ b/index.js
@@ -50,6 +50,8 @@ config.todoist.unmatchedDailyTask =
   config.todoist.unmatchedDailyTask || process.env.TODOIST_UNMATCHED_DAILY_TASK;
 config.dailyGoalTaskName =
   config.dailyGoalTaskName || process.env.DAILY_GOAL_TASK_NAME;
+config.habiticaOrphanAction =
+  config.habiticaOrphanAction || process.env.HABITICA_ORPHAN_ACTION;
 
 const todoist = Todoist.from(config.todoist.token, logger);
 const habitica = Habitica.from(

--- a/sync.js
+++ b/sync.js
@@ -32,8 +32,51 @@ module.exports = class Sync {
       .then((config) => this.scoreCompletedTasks(config))
       .then((config) => this.updateDailies(config))
       .then((config) => this.updateTasks(config))
+      .then((config) => this.handleOrphanedTasks(config))
       .then((config) => this.checkDailyGoal(config))
       .then((config) => this.syncChecklistItems(config));
+  }
+
+  findOrphanedHabiticaTasks(config) {
+    const todoistIds = new Set(
+      Object.keys(config.todoistLookup || {}).map(String),
+    );
+    return (config.habiticaTasks || []).filter(
+      (task) => task && task.alias && !todoistIds.has(String(task.alias)),
+    );
+  }
+
+  async handleOrphanedTasks(config) {
+    const orphans = this.findOrphanedHabiticaTasks(config);
+    if (orphans.length === 0) {
+      return config;
+    }
+    const action = (config.habiticaOrphanAction || "log").toLowerCase();
+    for (const orphan of orphans) {
+      const id = orphan._id || orphan.id;
+      this.logger.warn(
+        `Orphaned habitica task (no matching todoist task): [${id}] ${orphan.text} (alias: ${orphan.alias})`,
+      );
+      if (action === "score") {
+        try {
+          await this.habitica.scoreTask(id);
+          this.logger.info(`Scored orphaned task: ${orphan.text}`);
+        } catch (e) {
+          this.logger.error(`Failed to score orphaned task: ${orphan.text}`, e);
+        }
+      } else if (action === "delete") {
+        try {
+          await this.habitica.deleteTask(id);
+          this.logger.info(`Deleted orphaned task: ${orphan.text}`);
+        } catch (e) {
+          this.logger.error(
+            `Failed to delete orphaned task: ${orphan.text}`,
+            e,
+          );
+        }
+      }
+    }
+    return config;
   }
 
   getHabiticaTasks(config) {

--- a/test/loggerStub.js
+++ b/test/loggerStub.js
@@ -1,7 +1,18 @@
 "use strict";
 
 module.exports = class LoggerStub {
-  warn() {}
-  info(msg) {}
-  error() {}
+  constructor() {
+    this.warns = [];
+    this.infos = [];
+    this.errors = [];
+  }
+  warn(msg) {
+    this.warns.push(String(msg));
+  }
+  info(msg) {
+    this.infos.push(String(msg));
+  }
+  error(msg) {
+    this.errors.push(String(msg));
+  }
 };

--- a/test/sync.spec.js
+++ b/test/sync.spec.js
@@ -329,6 +329,84 @@ describe("sync", function () {
     });
   });
 
+  describe("handleOrphanedTasks", function () {
+    function makeConfig(habiticaTasks, todoistLookup, action) {
+      return {
+        habiticaTasks,
+        todoistLookup,
+        habiticaOrphanAction: action,
+      };
+    }
+
+    it("logs a warning for orphaned tasks", async function () {
+      const config = makeConfig(
+        [{ _id: "h1", alias: "missing-todoist-id", text: "Orphan" }],
+        {},
+      );
+      await this.sync.handleOrphanedTasks(config);
+      expect(
+        this.logger.warns.some((m) => m.includes("Orphaned habitica task")),
+      ).to.be.true;
+    });
+
+    it("skips habitica tasks without an alias", async function () {
+      const config = makeConfig([{ _id: "h1", text: "Manual task" }], {});
+      await this.sync.handleOrphanedTasks(config);
+      expect(
+        this.logger.warns.some((m) => m.includes("Orphaned habitica task")),
+      ).to.be.false;
+    });
+
+    it("does not flag habitica tasks whose alias matches a todoist task", async function () {
+      const config = makeConfig(
+        [{ _id: "h1", alias: "todo-1", text: "Existing" }],
+        { "todo-1": { id: "todo-1" } },
+      );
+      await this.sync.handleOrphanedTasks(config);
+      expect(
+        this.logger.warns.some((m) => m.includes("Orphaned habitica task")),
+      ).to.be.false;
+    });
+
+    it("scores orphaned tasks when action is 'score'", async function () {
+      this.habitica.tasks.push({
+        _id: "h1",
+        alias: "missing",
+        text: "Orphan",
+        checklist: [],
+      });
+      const config = makeConfig(this.habitica.tasks.slice(), {}, "score");
+      await this.sync.handleOrphanedTasks(config);
+      expect(this.habitica.getTask("h1").checked).to.equal(true);
+    });
+
+    it("deletes orphaned tasks when action is 'delete'", async function () {
+      this.habitica.tasks.push({
+        _id: "h1",
+        alias: "missing",
+        text: "Orphan",
+        checklist: [],
+      });
+      const config = makeConfig(this.habitica.tasks.slice(), {}, "delete");
+      await this.sync.handleOrphanedTasks(config);
+      expect(this.habitica.getTask("h1")).to.be.undefined;
+    });
+
+    it("does not score or delete when action is 'log'", async function () {
+      this.habitica.tasks.push({
+        _id: "h1",
+        alias: "missing",
+        text: "Orphan",
+        checklist: [],
+      });
+      const config = makeConfig(this.habitica.tasks.slice(), {}, "log");
+      await this.sync.handleOrphanedTasks(config);
+      const task = this.habitica.getTask("h1");
+      expect(task).to.exist;
+      expect(task.checked).to.be.undefined;
+    });
+  });
+
   describe("aliases via reduce", function () {
     it("builds aliases map from habitica tasks", async function () {
       // Pre-populate habitica with a known task


### PR DESCRIPTION
## Summary
- Detects habitica todos whose alias does not map to a current Todoist task and logs them as warnings on every sync.
- Adds `habiticaOrphanAction` config (env var `HABITICA_ORPHAN_ACTION`) supporting `log` (default), `score`, and `delete` to optionally automate cleanup.
- Documents the new behavior in the README.

Closes #150

## Test plan
- [x] `npm test` — 57 passing, including 6 new tests covering log/score/delete paths, the no-alias skip, and the matched-alias non-orphan case.
- [ ] Manual smoke: run a sync against a real account with `HABITICA_ORPHAN_ACTION=log` and confirm the warning fires for a deliberately deleted Todoist task.