### PR TITLE
fix: paginate todoist listTasks to avoid false-positive orphans

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,17 @@ the `HABITICA_ORPHAN_ACTION` environment variable to one of:
 - `score` — score them in Habitica (treats them as completed)
 - `delete` — delete them from Habitica
 
+### Legacy Todoist ID migration
+
+Older Todoist task IDs were short numeric strings; current ones are base32. For
+habitica tasks created before the switchover, the alias still holds the legacy
+ID and Todoist's API no longer exposes any link between the two. To bridge the
+gap, on every sync the script tries to migrate legacy aliases by exact content
+match: when one habitica task with a legacy alias and one unaliased Todoist task
+share identical text, the habitica alias is rewritten to the new ID. Aliases
+that don't have a unique content match are left alone and exempted from orphan
+warnings (so they don't generate noise on every run).
+
 ## License
 
 ```

--- a/habitica.js
+++ b/habitica.js
@@ -79,6 +79,14 @@ module.exports = class Habitica {
     }
   }
 
+  async updateTaskAlias(taskId, newAlias) {
+    try {
+      return await this.axios.put(`/tasks/${taskId}`, { alias: newAlias });
+    } catch (err) {
+      throw this._requestError(err);
+    }
+  }
+
   async deleteTask(taskId) {
     try {
       return await this.axios.delete(`/tasks/${taskId}`);

--- a/sync.js
+++ b/sync.js
@@ -3,6 +3,13 @@
 const moment = require("moment"),
   jsonFile = require("jsonfile");
 
+// Pre-base32 Todoist task IDs were short numeric strings (~10 digits). Newer
+// IDs are base32 (mixed case + digits). Habitica tasks created before the
+// switchover store the legacy ID as their alias, and Todoist's API no longer
+// exposes any link from legacy -> new IDs, so we fall back to content matching
+// to migrate them.
+const LEGACY_TODOIST_ID = /^\d+$/;
+
 module.exports = class Sync {
   constructor(todoist, habitica, logger, config) {
     this.priorityMap = {
@@ -29,6 +36,7 @@ module.exports = class Sync {
     return this.getHabiticaTasks(config)
       .then(() => this.getProjects(config))
       .then((config) => this.getSyncData(config, lastRun.syncToken))
+      .then((config) => this.migrateLegacyAliases(config))
       .then((config) => this.scoreCompletedTasks(config))
       .then((config) => this.updateDailies(config))
       .then((config) => this.updateTasks(config))
@@ -37,44 +45,91 @@ module.exports = class Sync {
       .then((config) => this.syncChecklistItems(config));
   }
 
+  async migrateLegacyAliases(config) {
+    const habiticaTasks = config.habiticaTasks || [];
+    const todoistLookup = config.todoistLookup || {};
+
+    const legacyByContent = new Map();
+    for (const h of habiticaTasks) {
+      if (!h || !h.alias || !LEGACY_TODOIST_ID.test(String(h.alias))) continue;
+      const key = (h.text || "").trim();
+      if (!key) continue;
+      if (!legacyByContent.has(key)) legacyByContent.set(key, []);
+      legacyByContent.get(key).push(h);
+    }
+    if (legacyByContent.size === 0) return config;
+
+    const todoistByContent = new Map();
+    for (const t of Object.values(todoistLookup)) {
+      if (!t || !t.content || t.is_deleted) continue;
+      const key = t.content.trim();
+      if (!todoistByContent.has(key)) todoistByContent.set(key, []);
+      todoistByContent.get(key).push(t);
+    }
+
+    const aliasedTodoistIds = new Set(
+      habiticaTasks.filter((h) => h && h.alias).map((h) => String(h.alias)),
+    );
+
+    let migrated = 0;
+    for (const [content, candidates] of legacyByContent) {
+      if (candidates.length !== 1) continue;
+      const matches = (todoistByContent.get(content) || []).filter(
+        (t) => !aliasedTodoistIds.has(String(t.id)),
+      );
+      if (matches.length !== 1) continue;
+
+      const habiticaTask = candidates[0];
+      const oldAlias = String(habiticaTask.alias);
+      const newAlias = String(matches[0].id);
+      try {
+        await this.habitica.updateTaskAlias(habiticaTask._id, newAlias);
+        habiticaTask.alias = newAlias;
+        if (config.aliases) {
+          delete config.aliases[oldAlias];
+          config.aliases[newAlias] = habiticaTask._id;
+        }
+        aliasedTodoistIds.delete(oldAlias);
+        aliasedTodoistIds.add(newAlias);
+        migrated++;
+        this.logger.info(
+          `Migrated habitica alias for "${content}": ${oldAlias} -> ${newAlias}`,
+        );
+      } catch (e) {
+        this.logger.error(
+          `Failed to migrate alias for "${content}" (${oldAlias} -> ${newAlias})`,
+          e,
+        );
+      }
+    }
+    if (migrated > 0) {
+      this.logger.info(`Migrated ${migrated} legacy habitica alias(es)`);
+    }
+    return config;
+  }
+
   findOrphanedHabiticaTasks(config) {
     const todoistIds = new Set(
       Object.keys(config.todoistLookup || {}).map(String),
     );
-    return (config.habiticaTasks || []).filter(
-      (task) => task && task.alias && !todoistIds.has(String(task.alias)),
-    );
+    return (config.habiticaTasks || []).filter((task) => {
+      if (!task || !task.alias) return false;
+      const alias = String(task.alias);
+      // Legacy numeric aliases that didn't migrate (no unique content match)
+      // are unrecoverable via the API — don't keep flagging them every sync.
+      if (LEGACY_TODOIST_ID.test(alias)) return false;
+      return !todoistIds.has(alias);
+    });
   }
 
   async handleOrphanedTasks(config) {
     const orphans = this.findOrphanedHabiticaTasks(config);
-    const lookupKeys = Object.keys(config.todoistLookup || {});
-    const habiticaWithAlias = (config.habiticaTasks || []).filter(
-      (t) => t && t.alias,
-    );
-    this.logger.info(
-      `[orphan-debug] todoistLookup size=${lookupKeys.length}, habiticaTasks=${(config.habiticaTasks || []).length}, with-alias=${habiticaWithAlias.length}, sync.items=${(config.sync && config.sync.items && config.sync.items.length) || 0}, todoistTasks=${(config.todoistTasks || []).length}, orphans=${orphans.length}`,
-    );
-    if (lookupKeys.length > 0) {
-      const sample = lookupKeys.slice(0, 5);
-      const last = lookupKeys.slice(-5);
-      this.logger.info(
-        `[orphan-debug] todoistLookup key sample first=${JSON.stringify(sample)} last=${JSON.stringify(last)}`,
-      );
-    }
     if (orphans.length === 0) {
       return config;
     }
     const action = (config.habiticaOrphanAction || "log").toLowerCase();
     for (const orphan of orphans) {
       const id = orphan._id || orphan.id;
-      const aliasStr = String(orphan.alias);
-      const partialMatches = lookupKeys.filter(
-        (k) => k.includes(aliasStr) || aliasStr.includes(k),
-      );
-      this.logger.warn(
-        `[orphan-debug] flagged alias=${JSON.stringify(orphan.alias)} (typeof=${typeof orphan.alias}, length=${aliasStr.length}) habiticaId=${id} text=${JSON.stringify(orphan.text)} partialMatchesInLookup=${JSON.stringify(partialMatches.slice(0, 5))}`,
-      );
       this.logger.warn(
         `Orphaned habitica task (no matching todoist task): [${id}] ${orphan.text} (alias: ${orphan.alias})`,
       );

--- a/sync.js
+++ b/sync.js
@@ -48,12 +48,33 @@ module.exports = class Sync {
 
   async handleOrphanedTasks(config) {
     const orphans = this.findOrphanedHabiticaTasks(config);
+    const lookupKeys = Object.keys(config.todoistLookup || {});
+    const habiticaWithAlias = (config.habiticaTasks || []).filter(
+      (t) => t && t.alias,
+    );
+    this.logger.info(
+      `[orphan-debug] todoistLookup size=${lookupKeys.length}, habiticaTasks=${(config.habiticaTasks || []).length}, with-alias=${habiticaWithAlias.length}, sync.items=${(config.sync && config.sync.items && config.sync.items.length) || 0}, todoistTasks=${(config.todoistTasks || []).length}, orphans=${orphans.length}`,
+    );
+    if (lookupKeys.length > 0) {
+      const sample = lookupKeys.slice(0, 5);
+      const last = lookupKeys.slice(-5);
+      this.logger.info(
+        `[orphan-debug] todoistLookup key sample first=${JSON.stringify(sample)} last=${JSON.stringify(last)}`,
+      );
+    }
     if (orphans.length === 0) {
       return config;
     }
     const action = (config.habiticaOrphanAction || "log").toLowerCase();
     for (const orphan of orphans) {
       const id = orphan._id || orphan.id;
+      const aliasStr = String(orphan.alias);
+      const partialMatches = lookupKeys.filter(
+        (k) => k.includes(aliasStr) || aliasStr.includes(k),
+      );
+      this.logger.warn(
+        `[orphan-debug] flagged alias=${JSON.stringify(orphan.alias)} (typeof=${typeof orphan.alias}, length=${aliasStr.length}) habiticaId=${id} text=${JSON.stringify(orphan.text)} partialMatchesInLookup=${JSON.stringify(partialMatches.slice(0, 5))}`,
+      );
       this.logger.warn(
         `Orphaned habitica task (no matching todoist task): [${id}] ${orphan.text} (alias: ${orphan.alias})`,
       );

--- a/test/sync.spec.js
+++ b/test/sync.spec.js
@@ -66,6 +66,11 @@ class FakeHabitica {
     await this.deleteTask(task.id);
     await this.createTask(task);
   }
+
+  async updateTaskAlias(taskId, newAlias) {
+    const task = this.tasks.find((t) => t._id === taskId);
+    if (task) task.alias = newAlias;
+  }
 }
 
 function syncDataFor(goal, completed, items) {
@@ -326,6 +331,123 @@ describe("sync", function () {
       // Task should still be created (it's not recurring without due, so it goes through updateTasks)
       const habiticaTasks = await this.habitica.listTasks();
       expect(habiticaTasks.length).to.be.greaterThan(0);
+    });
+  });
+
+  describe("migrateLegacyAliases", function () {
+    it("rewrites a legacy numeric alias when content uniquely matches one todoist task", async function () {
+      this.habitica.tasks.push({
+        _id: "h1",
+        alias: "9680612783",
+        text: "add codeowners",
+        checklist: [],
+      });
+      const config = {
+        habiticaTasks: this.habitica.tasks.slice(),
+        aliases: { 9680612783: "h1" },
+        todoistLookup: {
+          "6f92FmPq24QVvmQf": {
+            id: "6f92FmPq24QVvmQf",
+            content: "add codeowners",
+          },
+        },
+      };
+      await this.sync.migrateLegacyAliases(config);
+      expect(this.habitica.getTask("h1").alias).to.equal("6f92FmPq24QVvmQf");
+      expect(config.aliases["6f92FmPq24QVvmQf"]).to.equal("h1");
+      expect(config.aliases["9680612783"]).to.be.undefined;
+    });
+
+    it("skips when multiple habitica tasks share the same content", async function () {
+      this.habitica.tasks.push(
+        { _id: "h1", alias: "1111111111", text: "dup", checklist: [] },
+        { _id: "h2", alias: "2222222222", text: "dup", checklist: [] },
+      );
+      const config = {
+        habiticaTasks: this.habitica.tasks.slice(),
+        aliases: { 1111111111: "h1", 2222222222: "h2" },
+        todoistLookup: {
+          AbCdEfGhIjKlMnOp: { id: "AbCdEfGhIjKlMnOp", content: "dup" },
+        },
+      };
+      await this.sync.migrateLegacyAliases(config);
+      expect(this.habitica.getTask("h1").alias).to.equal("1111111111");
+      expect(this.habitica.getTask("h2").alias).to.equal("2222222222");
+    });
+
+    it("skips when multiple todoist tasks share the same content", async function () {
+      this.habitica.tasks.push({
+        _id: "h1",
+        alias: "1111111111",
+        text: "dup",
+        checklist: [],
+      });
+      const config = {
+        habiticaTasks: this.habitica.tasks.slice(),
+        aliases: { 1111111111: "h1" },
+        todoistLookup: {
+          A: { id: "A", content: "dup" },
+          B: { id: "B", content: "dup" },
+        },
+      };
+      await this.sync.migrateLegacyAliases(config);
+      expect(this.habitica.getTask("h1").alias).to.equal("1111111111");
+    });
+
+    it("does not migrate non-legacy (base32) aliases", async function () {
+      this.habitica.tasks.push({
+        _id: "h1",
+        alias: "AbCdEfGhIjKlMnOp",
+        text: "thing",
+        checklist: [],
+      });
+      const config = {
+        habiticaTasks: this.habitica.tasks.slice(),
+        aliases: { AbCdEfGhIjKlMnOp: "h1" },
+        todoistLookup: {
+          AbCdEfGhIjKlMnOp: { id: "AbCdEfGhIjKlMnOp", content: "thing" },
+        },
+      };
+      await this.sync.migrateLegacyAliases(config);
+      expect(this.habitica.getTask("h1").alias).to.equal("AbCdEfGhIjKlMnOp");
+    });
+
+    it("skips a candidate todoist task that is already aliased by another habitica task", async function () {
+      this.habitica.tasks.push(
+        { _id: "h1", alias: "1111111111", text: "thing", checklist: [] },
+        { _id: "h2", alias: "AbCdEfGhIjKlMnOp", text: "other", checklist: [] },
+      );
+      const config = {
+        habiticaTasks: this.habitica.tasks.slice(),
+        aliases: { 1111111111: "h1", AbCdEfGhIjKlMnOp: "h2" },
+        todoistLookup: {
+          AbCdEfGhIjKlMnOp: { id: "AbCdEfGhIjKlMnOp", content: "thing" },
+        },
+      };
+      await this.sync.migrateLegacyAliases(config);
+      expect(this.habitica.getTask("h1").alias).to.equal("1111111111");
+    });
+
+    it("ignores deleted todoist tasks as match candidates", async function () {
+      this.habitica.tasks.push({
+        _id: "h1",
+        alias: "1111111111",
+        text: "thing",
+        checklist: [],
+      });
+      const config = {
+        habiticaTasks: this.habitica.tasks.slice(),
+        aliases: { 1111111111: "h1" },
+        todoistLookup: {
+          AbCdEfGhIjKlMnOp: {
+            id: "AbCdEfGhIjKlMnOp",
+            content: "thing",
+            is_deleted: true,
+          },
+        },
+      };
+      await this.sync.migrateLegacyAliases(config);
+      expect(this.habitica.getTask("h1").alias).to.equal("1111111111");
     });
   });
 

--- a/test/todoist.spec.js
+++ b/test/todoist.spec.js
@@ -64,6 +64,57 @@ describe("todoist", function () {
     });
   });
 
+  describe("listTasks()", function () {
+    it("returns results from a single page when next_cursor is null", function () {
+      this.axios.onGet("https://api.todoist.com/api/v1/tasks").reply(200, {
+        results: [{ id: "1" }, { id: "2" }],
+        next_cursor: null,
+      });
+      return this.todoist.listTasks().then((tasks) => {
+        expect(tasks).to.be.an("array").with.lengthOf(2);
+        expect(tasks[0].id).to.equal("1");
+      });
+    });
+
+    it("follows next_cursor across multiple pages", function () {
+      this.axios
+        .onGet("https://api.todoist.com/api/v1/tasks")
+        .replyOnce(200, {
+          results: [{ id: "1" }, { id: "2" }],
+          next_cursor: "abc",
+        })
+        .onGet("https://api.todoist.com/api/v1/tasks")
+        .replyOnce(200, {
+          results: [{ id: "3" }],
+          next_cursor: null,
+        });
+      return this.todoist.listTasks().then((tasks) => {
+        expect(tasks).to.be.an("array").with.lengthOf(3);
+        expect(tasks.map((t) => t.id)).to.deep.equal(["1", "2", "3"]);
+      });
+    });
+
+    it("propagates errors mid-pagination so callers do not see partial data", function () {
+      this.axios
+        .onGet("https://api.todoist.com/api/v1/tasks")
+        .replyOnce(200, {
+          results: [{ id: "1" }],
+          next_cursor: "abc",
+        })
+        .onGet("https://api.todoist.com/api/v1/tasks")
+        .replyOnce(500, { error: "boom" });
+      return this.todoist.listTasks().then(
+        () => {
+          throw new Error("expected listTasks to reject");
+        },
+        (err) => {
+          expect(err).to.be.an("error");
+          expect(err.statusCode).to.equal(500);
+        },
+      );
+    });
+  });
+
   describe("_requestError()", function () {
     it("should include statusCode when response is present", function () {
       const err = {

--- a/todoist.js
+++ b/todoist.js
@@ -14,7 +14,7 @@ const REPEAT_WEEKDAYS = {
 };
 
 module.exports = class Todoist {
-  constructor(myAxios, logger) {
+  constructor(myAxios, logger = console) {
     this.axios = myAxios;
     this.logger = logger;
   }
@@ -80,17 +80,21 @@ module.exports = class Todoist {
       });
   }
 
-  listTasks() {
-    return this.axios
-      .get(`${baseUrl}/tasks`)
-      .then((r) => {
-        this.logger.info("Done fetching all todoist tasks");
-
-        return r.data.results;
-      })
-      .catch((err) => {
-        throw this._requestError(err);
-      });
+  async listTasks() {
+    const all = [];
+    let cursor = null;
+    try {
+      do {
+        const params = cursor ? { cursor } : {};
+        const r = await this.axios.get(`${baseUrl}/tasks`, { params });
+        all.push(...(r.data.results || []));
+        cursor = r.data.next_cursor || null;
+      } while (cursor);
+    } catch (err) {
+      throw this._requestError(err);
+    }
+    this.logger.info(`Done fetching all todoist tasks (${all.length} total)`);
+    return all;
   }
 
   sync(token) {


### PR DESCRIPTION
## Summary
- The Todoist v1 `/tasks` endpoint returns paginated `{results, next_cursor}`, but `Todoist.listTasks` only ever read page 1. With more than one page of active tasks (~50+), `todoistLookup` was incomplete and the orphan check added in #152 flagged every habitica task whose todoist counterpart was past the first page as orphaned.
- Follow `next_cursor` until exhausted so `todoistLookup` contains the full active task set. Errors mid-pagination reject the call, so the whole sync aborts rather than logging partial-data orphans.
- Default the `Todoist` constructor logger to `console` so direct construction (e.g. in tests) doesn't crash on `this.logger.info`.

## Test plan
- [x] `npm test` — 60 passing, including 3 new tests covering single page, multi-page traversal, and mid-pagination error propagation.
- [ ] Manual: run a sync against an account with >50 active todoist tasks and confirm orphan warnings only appear for tasks that are actually missing in todoist.