### PR TITLE
feat: flag unmigratable legacy aliases as orphan candidates

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,14 @@ completed outside the sync window) and you'll likely want to clean them up.
 Legacy aliases whose content matches more than one active Todoist task are
 left alone (we can't tell which is which).
 
+Legacy-unmigrated orphans can be acted on independently of regular orphans via
+`habiticaLegacyOrphanAction` in `config.json` or the
+`HABITICA_LEGACY_ORPHAN_ACTION` environment variable. It accepts the same
+`log` / `score` / `delete` values and falls back to `habiticaOrphanAction` when
+unset. Useful when you want to be conservative about regular orphans (e.g.
+`log`) but auto-handle the legacy ones (e.g. `score` since they were valid
+tasks at one point, or `delete` to clean them out).
+
 ## License
 
 ```

--- a/README.md
+++ b/README.md
@@ -46,9 +46,13 @@ habitica tasks created before the switchover, the alias still holds the legacy
 ID and Todoist's API no longer exposes any link between the two. To bridge the
 gap, on every sync the script tries to migrate legacy aliases by exact content
 match: when one habitica task with a legacy alias and one unaliased Todoist task
-share identical text, the habitica alias is rewritten to the new ID. Aliases
-that don't have a unique content match are left alone and exempted from orphan
-warnings (so they don't generate noise on every run).
+share identical text, the habitica alias is rewritten to the new ID. Legacy
+aliases whose content doesn't match any active Todoist task are flagged as
+orphans with a `legacy alias couldn't be migrated... candidate for deletion`
+note — those are habitica tasks whose Todoist counterpart is gone (deleted or
+completed outside the sync window) and you'll likely want to clean them up.
+Legacy aliases whose content matches more than one active Todoist task are
+left alone (we can't tell which is which).
 
 ## License
 

--- a/index.js
+++ b/index.js
@@ -52,6 +52,9 @@ config.dailyGoalTaskName =
   config.dailyGoalTaskName || process.env.DAILY_GOAL_TASK_NAME;
 config.habiticaOrphanAction =
   config.habiticaOrphanAction || process.env.HABITICA_ORPHAN_ACTION;
+config.habiticaLegacyOrphanAction =
+  config.habiticaLegacyOrphanAction ||
+  process.env.HABITICA_LEGACY_ORPHAN_ACTION;
 
 const todoist = Todoist.from(config.todoist.token, logger);
 const habitica = Habitica.from(

--- a/sync.js
+++ b/sync.js
@@ -143,13 +143,19 @@ module.exports = class Sync {
     if (orphans.length === 0) {
       return config;
     }
-    const action = (config.habiticaOrphanAction || "log").toLowerCase();
+    const baseAction = (config.habiticaOrphanAction || "log").toLowerCase();
+    const legacyAction = (
+      config.habiticaLegacyOrphanAction ||
+      config.habiticaOrphanAction ||
+      "log"
+    ).toLowerCase();
     for (const { task: orphan, reason } of orphans) {
       const id = orphan._id || orphan.id;
-      const detail =
-        reason === "legacy-unmigrated"
-          ? "legacy alias couldn't be migrated, no content match in active todoist tasks - candidate for deletion"
-          : "no matching todoist task";
+      const isLegacy = reason === "legacy-unmigrated";
+      const action = isLegacy ? legacyAction : baseAction;
+      const detail = isLegacy
+        ? "legacy alias couldn't be migrated, no content match in active todoist tasks - candidate for deletion"
+        : "no matching todoist task";
       this.logger.warn(
         `Orphaned habitica task (${detail}): [${id}] ${orphan.text} (alias: ${orphan.alias})`,
       );

--- a/sync.js
+++ b/sync.js
@@ -112,14 +112,30 @@ module.exports = class Sync {
     const todoistIds = new Set(
       Object.keys(config.todoistLookup || {}).map(String),
     );
-    return (config.habiticaTasks || []).filter((task) => {
-      if (!task || !task.alias) return false;
+    const activeContent = new Set(
+      Object.values(config.todoistLookup || {})
+        .filter((t) => t && t.content && !t.is_deleted)
+        .map((t) => t.content.trim()),
+    );
+    const orphans = [];
+    for (const task of config.habiticaTasks || []) {
+      if (!task || !task.alias) continue;
       const alias = String(task.alias);
-      // Legacy numeric aliases that didn't migrate (no unique content match)
-      // are unrecoverable via the API — don't keep flagging them every sync.
-      if (LEGACY_TODOIST_ID.test(alias)) return false;
-      return !todoistIds.has(alias);
-    });
+      if (LEGACY_TODOIST_ID.test(alias)) {
+        // Migration runs first; if a legacy alias is still here, no unique
+        // content match was found. If the content doesn't match ANY active
+        // Todoist task, the source is gone (deleted or completed outside the
+        // sync window) and this is a deletion candidate. If it matches one
+        // ambiguously, leave it alone — we can't tell which task is which.
+        const text = (task.text || "").trim();
+        if (text && !activeContent.has(text)) {
+          orphans.push({ task, reason: "legacy-unmigrated" });
+        }
+      } else if (!todoistIds.has(alias)) {
+        orphans.push({ task, reason: "missing" });
+      }
+    }
+    return orphans;
   }
 
   async handleOrphanedTasks(config) {
@@ -128,10 +144,14 @@ module.exports = class Sync {
       return config;
     }
     const action = (config.habiticaOrphanAction || "log").toLowerCase();
-    for (const orphan of orphans) {
+    for (const { task: orphan, reason } of orphans) {
       const id = orphan._id || orphan.id;
+      const detail =
+        reason === "legacy-unmigrated"
+          ? "legacy alias couldn't be migrated, no content match in active todoist tasks - candidate for deletion"
+          : "no matching todoist task";
       this.logger.warn(
-        `Orphaned habitica task (no matching todoist task): [${id}] ${orphan.text} (alias: ${orphan.alias})`,
+        `Orphaned habitica task (${detail}): [${id}] ${orphan.text} (alias: ${orphan.alias})`,
       );
       if (action === "score") {
         try {

--- a/test/sync.spec.js
+++ b/test/sync.spec.js
@@ -577,6 +577,75 @@ describe("sync", function () {
       );
       expect(matched).to.exist;
     });
+
+    it("scores a legacy-unmigrated orphan when habiticaLegacyOrphanAction is 'score'", async function () {
+      this.habitica.tasks.push({
+        _id: "h1",
+        alias: "9680612783",
+        text: "old task",
+        checklist: [],
+      });
+      const config = {
+        habiticaTasks: this.habitica.tasks.slice(),
+        todoistLookup: {},
+        habiticaOrphanAction: "log",
+        habiticaLegacyOrphanAction: "score",
+      };
+      await this.sync.handleOrphanedTasks(config);
+      expect(this.habitica.getTask("h1").checked).to.equal(true);
+    });
+
+    it("deletes a legacy-unmigrated orphan when habiticaLegacyOrphanAction is 'delete'", async function () {
+      this.habitica.tasks.push({
+        _id: "h1",
+        alias: "9680612783",
+        text: "old task",
+        checklist: [],
+      });
+      const config = {
+        habiticaTasks: this.habitica.tasks.slice(),
+        todoistLookup: {},
+        habiticaOrphanAction: "log",
+        habiticaLegacyOrphanAction: "delete",
+      };
+      await this.sync.handleOrphanedTasks(config);
+      expect(this.habitica.getTask("h1")).to.be.undefined;
+    });
+
+    it("legacy orphans inherit habiticaOrphanAction when no legacy override is set", async function () {
+      this.habitica.tasks.push({
+        _id: "h1",
+        alias: "9680612783",
+        text: "old task",
+        checklist: [],
+      });
+      const config = {
+        habiticaTasks: this.habitica.tasks.slice(),
+        todoistLookup: {},
+        habiticaOrphanAction: "score",
+      };
+      await this.sync.handleOrphanedTasks(config);
+      expect(this.habitica.getTask("h1").checked).to.equal(true);
+    });
+
+    it("legacy override does not affect base32 orphans", async function () {
+      this.habitica.tasks.push({
+        _id: "h1",
+        alias: "AbCdEfGhIjKlMnOp",
+        text: "active task",
+        checklist: [],
+      });
+      const config = {
+        habiticaTasks: this.habitica.tasks.slice(),
+        todoistLookup: {},
+        habiticaOrphanAction: "log",
+        habiticaLegacyOrphanAction: "delete",
+      };
+      await this.sync.handleOrphanedTasks(config);
+      const task = this.habitica.getTask("h1");
+      expect(task).to.exist;
+      expect(task.checked).to.be.undefined;
+    });
   });
 
   describe("aliases via reduce", function () {

--- a/test/sync.spec.js
+++ b/test/sync.spec.js
@@ -527,6 +527,56 @@ describe("sync", function () {
       expect(task).to.exist;
       expect(task.checked).to.be.undefined;
     });
+
+    it("flags a legacy-aliased task whose content does not match any active todoist task", async function () {
+      const config = makeConfig(
+        [{ _id: "h1", alias: "9680612783", text: "old task" }],
+        {
+          AbCdEfGhIjKlMnOp: {
+            id: "AbCdEfGhIjKlMnOp",
+            content: "something different",
+          },
+        },
+      );
+      await this.sync.handleOrphanedTasks(config);
+      const matched = this.logger.warns.find((m) =>
+        m.includes("legacy alias couldn't be migrated"),
+      );
+      expect(matched).to.exist;
+      expect(matched).to.include("candidate for deletion");
+    });
+
+    it("does not flag a legacy-aliased task whose content matches an active todoist task", async function () {
+      const config = makeConfig(
+        [{ _id: "h1", alias: "9680612783", text: "shared name" }],
+        {
+          A: { id: "A", content: "shared name" },
+          B: { id: "B", content: "shared name" },
+        },
+      );
+      await this.sync.handleOrphanedTasks(config);
+      expect(
+        this.logger.warns.some((m) => m.includes("Orphaned habitica task")),
+      ).to.be.false;
+    });
+
+    it("ignores deleted todoist tasks when content-matching legacy aliases", async function () {
+      const config = makeConfig(
+        [{ _id: "h1", alias: "9680612783", text: "thing" }],
+        {
+          AbCdEfGhIjKlMnOp: {
+            id: "AbCdEfGhIjKlMnOp",
+            content: "thing",
+            is_deleted: true,
+          },
+        },
+      );
+      await this.sync.handleOrphanedTasks(config);
+      const matched = this.logger.warns.find((m) =>
+        m.includes("legacy alias couldn't be migrated"),
+      );
+      expect(matched).to.exist;
+    });
   });
 
   describe("aliases via reduce", function () {


### PR DESCRIPTION
## Summary
Follow-up to #154. Two related changes:

**Flag unmigratable legacy aliases as orphan candidates.** Previously, legacy-aliased habitica tasks were exempted from orphan detection entirely because Todoist exposes no way to verify them by ID. That hid a legitimate case: legacy-aliased tasks whose Todoist counterpart was deleted or completed outside the sync window. Migration can't rewrite them (no content match in active tasks) and orphan detection skipped them — so they sat in habitica forever, silent.

This PR uses content as the verification signal for legacy aliases:
- If a legacy-aliased habitica task's `text` doesn't match any active Todoist task's `content`, flag it as an orphan with a distinct message: `legacy alias couldn't be migrated... candidate for deletion`.
- Legacy aliases whose content matches one or more active Todoist tasks are still left alone (migration handles the unique case; ambiguous cases can't be safely resolved).

**Add `habiticaLegacyOrphanAction` for per-type control.** A new env var `HABITICA_LEGACY_ORPHAN_ACTION` (and matching config key) controls how legacy-unmigrated orphans are handled independently of regular orphans. Defaults to `habiticaOrphanAction` when unset, so existing setups don't change behavior. Useful when you've manually verified the legacy orphans (they were valid tasks at some point) and want to auto-score or auto-delete them, while keeping a more conservative log-only policy on regular orphans that may have been intentionally deleted in Todoist.

## Test plan
- [x] `npm test` — 73 passing, including 3 tests for the legacy-orphan flagging and 4 for the new per-type action.
- [ ] Set `HABITICA_LEGACY_ORPHAN_ACTION=score` and confirm the previously-orphaned legacy tasks get scored on the next sync.